### PR TITLE
feat/use macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1.0.75"
 async-ssh2-tokio = "0.7.1"
 async-trait = "0.1.73"
 config = "0.13.3"
+paste = "1.0.14"
 russh = "0.38.0"
 russh-keys = "0.38.0"
 

--- a/src/bandit/mod.rs
+++ b/src/bandit/mod.rs
@@ -15,14 +15,30 @@
 // Major portions of this file come from russh's examples
 // https://github.com/warp-tech/russh/blob/main/russh/examples/remote_shell_call.rs
 
+use paste::paste;
+
 use crate::get_ssh_client_from_settings;
 
-#[cfg(not(tarpaulin_include))]
-pub async fn level1_password() -> String {
-    let client = get_ssh_client_from_settings("bandit", 0).await;
-    let result = client.execute("cat readme").await.unwrap();
-    result.stdout.trim().to_string()
+macro_rules! level_password {
+    ($level:literal) => {
+        paste! {
+            pub async fn [<level $level _password>]() -> String {
+                let client = get_ssh_client_from_settings("bandit", $level - 1).await;
+                let result = client.execute("cat readme").await.unwrap();
+                result.stdout.trim().to_string()
+            }
+        }
+    };
 }
+
+level_password!(1);
+
+// #[cfg(not(tarpaulin_include))]
+// pub async fn level1_password() -> String {
+//     let client = get_ssh_client_from_settings("bandit", 0).await;
+//     let result = client.execute("cat readme").await.unwrap();
+//     result.stdout.trim().to_string()
+// }
 
 #[cfg(not(tarpaulin_include))]
 pub async fn level2_password() -> String {
@@ -180,12 +196,12 @@ mod tests {
     //     assert_eq!(0, result.exit_status);
     // }
 
-    // #[tokio::test]
-    // async fn level1_password_returns_proper_value() {
-    //     let client =
-    //         get_ssh_client_from_settings_with_password("bandit", 1, level1_password().await).await;
-    //     let result = client.execute("echo hello").await.unwrap();
-    //     assert_eq!("hello\n", result.stdout);
-    //     assert_eq!(0, result.exit_status);
-    // }
+    #[tokio::test]
+    async fn level1_password_returns_proper_value() {
+        let client =
+            get_ssh_client_from_settings_with_password("bandit", 1, level1_password().await).await;
+        let result = client.execute("echo hello").await.unwrap();
+        assert_eq!("hello\n", result.stdout);
+        assert_eq!(0, result.exit_status);
+    }
 }

--- a/src/bandit/mod.rs
+++ b/src/bandit/mod.rs
@@ -124,6 +124,8 @@ mod tests {
     #[allow(unused_imports)]
     use crate::get_ssh_client_from_settings_with_password;
 
+    test_ssh_wargame_level!("bandit", 1);
+
     // #[tokio::test]
     // async fn level9_password_returns_proper_value() {
     //     let client =
@@ -195,13 +197,4 @@ mod tests {
     //     assert_eq!("hello\n", result.stdout);
     //     assert_eq!(0, result.exit_status);
     // }
-
-    #[tokio::test]
-    async fn level1_password_returns_proper_value() {
-        let client =
-            get_ssh_client_from_settings_with_password("bandit", 1, level1_password().await).await;
-        let result = client.execute("echo hello").await.unwrap();
-        assert_eq!("hello\n", result.stdout);
-        assert_eq!(0, result.exit_status);
-    }
 }

--- a/src/bandit/mod.rs
+++ b/src/bandit/mod.rs
@@ -17,7 +17,7 @@
 
 use paste::paste;
 
-use crate::{get_ssh_client_from_settings, ssh_single_command_level};
+use crate::macros::ssh_single_command_level;
 
 macro_rules! bandit_single_command_level {
     ($level:literal, $command:literal) => {
@@ -50,7 +50,7 @@ mod tests {
     #[allow(unused_imports)]
     use super::*;
     #[allow(unused_imports)]
-    use crate::{get_ssh_client_from_settings_with_password, test_ssh_level};
+    use crate::macros::test_ssh_level;
 
     #[allow(unused_macros)]
     macro_rules! test_bandit_level {

--- a/src/bandit/mod.rs
+++ b/src/bandit/mod.rs
@@ -122,7 +122,7 @@ mod tests {
     #[allow(unused_imports)]
     use super::*;
     #[allow(unused_imports)]
-    use crate::get_ssh_client_from_settings_with_password;
+    use crate::{get_ssh_client_from_settings_with_password, test_ssh_level};
 
     test_ssh_level!("bandit", 1);
 

--- a/src/bandit/mod.rs
+++ b/src/bandit/mod.rs
@@ -124,7 +124,7 @@ mod tests {
     #[allow(unused_imports)]
     use crate::get_ssh_client_from_settings_with_password;
 
-    test_ssh_wargame_level!("bandit", 1);
+    test_ssh_level!("bandit", 1);
 
     // #[tokio::test]
     // async fn level9_password_returns_proper_value() {

--- a/src/bandit/mod.rs
+++ b/src/bandit/mod.rs
@@ -26,89 +26,23 @@ macro_rules! bandit_single_command_level {
 }
 
 bandit_single_command_level!(1, "cat readme");
-
-// #[cfg(not(tarpaulin_include))]
-// pub async fn level1_password() -> String {
-//     let client = get_ssh_client_from_settings("bandit", 0).await;
-//     let result = client.execute("cat readme").await.unwrap();
-//     result.stdout.trim().to_string()
-// }
-
-#[cfg(not(tarpaulin_include))]
-pub async fn level2_password() -> String {
-    let client = get_ssh_client_from_settings("bandit", 1).await;
-    let result = client.execute("cat ./-").await.unwrap();
-    result.stdout.trim().to_string()
-}
-
-#[cfg(not(tarpaulin_include))]
-pub async fn level3_password() -> String {
-    let client = get_ssh_client_from_settings("bandit", 2).await;
-    let result = client
-        .execute("cat \"./spaces in this filename\"")
-        .await
-        .unwrap();
-    result.stdout.trim().to_string()
-}
-
-#[cfg(not(tarpaulin_include))]
-pub async fn level4_password() -> String {
-    let client = get_ssh_client_from_settings("bandit", 3).await;
-    let result = client.execute("cat \"./inhere/.hidden\"").await.unwrap();
-    result.stdout.trim().to_string()
-}
-
-#[cfg(not(tarpaulin_include))]
-pub async fn level5_password() -> String {
-    let client = get_ssh_client_from_settings("bandit", 4).await;
-    let result = client
-        .execute(
-            "find ./inhere -type f -exec file {} + | awk -F: '/ ASCII text/{print $1}' | xargs cat",
-        )
-        .await
-        .unwrap();
-    result.stdout.trim().to_string()
-}
-
-#[cfg(not(tarpaulin_include))]
-pub async fn level6_password() -> String {
-    let client = get_ssh_client_from_settings("bandit", 5).await;
-    let result = client
-        .execute("find ./inhere -type f -size 1033c ! -perm /0111 | xargs cat")
-        .await
-        .unwrap();
-    result.stdout.trim().to_string()
-}
-
-#[cfg(not(tarpaulin_include))]
-pub async fn level7_password() -> String {
-    let client = get_ssh_client_from_settings("bandit", 6).await;
-    let result = client
-        .execute("find / -size 33c -group bandit6 -user bandit7 -print 2>/dev/null | xargs cat")
-        .await
-        .unwrap();
-    result.stdout.trim().to_string()
-}
-
-#[cfg(not(tarpaulin_include))]
-pub async fn level8_password() -> String {
-    let client = get_ssh_client_from_settings("bandit", 7).await;
-    let result = client
-        .execute("grep 'millionth' ./data.txt | awk '{print $2}'")
-        .await
-        .unwrap();
-    result.stdout.trim().to_string()
-}
-
-#[cfg(not(tarpaulin_include))]
-pub async fn level9_password() -> String {
-    let client = get_ssh_client_from_settings("bandit", 8).await;
-    let result = client
-        .execute("cat data.txt | sort | uniq -u")
-        .await
-        .unwrap();
-    result.stdout.trim().to_string()
-}
+bandit_single_command_level!(2, "cat ./-");
+bandit_single_command_level!(3, "cat \"./spaces in this filename\"");
+bandit_single_command_level!(4, "cat \"./inhere/.hidden\"");
+bandit_single_command_level!(
+    5,
+    "find ./inhere -type f -exec file {} + | awk -F: '/ ASCII text/{print $1}' | xargs cat"
+);
+bandit_single_command_level!(
+    6,
+    "find ./inhere -type f -size 1033c ! -perm /0111 | xargs cat"
+);
+bandit_single_command_level!(
+    7,
+    "find / -size 33c -group bandit6 -user bandit7 -print 2>/dev/null | xargs cat"
+);
+bandit_single_command_level!(8, "grep 'millionth' ./data.txt | awk '{print $2}'");
+bandit_single_command_level!(9, "cat data.txt | sort | uniq -u");
 
 #[cfg(not(tarpaulin_include))]
 #[cfg(test)]
@@ -133,5 +67,5 @@ mod tests {
     // test_bandit_level!(4);
     // test_bandit_level!(3);
     // test_bandit_level!(2);
-    test_bandit_level!(1);
+    // test_bandit_level!(1);
 }

--- a/src/bandit/mod.rs
+++ b/src/bandit/mod.rs
@@ -17,21 +17,15 @@
 
 use paste::paste;
 
-use crate::get_ssh_client_from_settings;
+use crate::{get_ssh_client_from_settings, ssh_single_command_level};
 
-macro_rules! level_password {
-    ($level:literal) => {
-        paste! {
-            pub async fn [<level $level _password>]() -> String {
-                let client = get_ssh_client_from_settings("bandit", $level - 1).await;
-                let result = client.execute("cat readme").await.unwrap();
-                result.stdout.trim().to_string()
-            }
-        }
+macro_rules! bandit_single_command_level {
+    ($level:literal, $command:literal) => {
+        ssh_single_command_level!("bandit", $level, $command);
     };
 }
 
-level_password!(1);
+bandit_single_command_level!(1, "cat readme");
 
 // #[cfg(not(tarpaulin_include))]
 // pub async fn level1_password() -> String {
@@ -139,5 +133,5 @@ mod tests {
     // test_bandit_level!(4);
     // test_bandit_level!(3);
     // test_bandit_level!(2);
-    // test_bandit_level!(1);
+    test_bandit_level!(1);
 }

--- a/src/bandit/mod.rs
+++ b/src/bandit/mod.rs
@@ -124,77 +124,20 @@ mod tests {
     #[allow(unused_imports)]
     use crate::{get_ssh_client_from_settings_with_password, test_ssh_level};
 
-    test_ssh_level!("bandit", 1);
+    #[allow(unused_macros)]
+    macro_rules! test_bandit_level {
+        ($level:literal) => {
+            test_ssh_level!("bandit", $level);
+        };
+    }
 
-    // #[tokio::test]
-    // async fn level9_password_returns_proper_value() {
-    //     let client =
-    //         get_ssh_client_from_settings_with_password("bandit", 9, level9_password().await).await;
-    //     let result = client.execute("echo hello").await.unwrap();
-    //     assert_eq!("hello\n", result.stdout);
-    //     assert_eq!(0, result.exit_status);
-    // }
-
-    // #[tokio::test]
-    // async fn level8_password_returns_proper_value() {
-    //     let client =
-    //         get_ssh_client_from_settings_with_password("bandit", 8, level8_password().await).await;
-    //     let result = client.execute("echo hello").await.unwrap();
-    //     assert_eq!("hello\n", result.stdout);
-    //     assert_eq!(0, result.exit_status);
-    // }
-
-    // #[tokio::test]
-    // async fn level7_password_returns_proper_value() {
-    //     let client =
-    //         get_ssh_client_from_settings_with_password("bandit", 7, level7_password().await).await;
-    //     let result = client.execute("echo hello").await.unwrap();
-    //     assert_eq!("hello\n", result.stdout);
-    //     assert_eq!(0, result.exit_status);
-    // }
-
-    // #[tokio::test]
-    // async fn level6_password_returns_proper_value() {
-    //     let client =
-    //         get_ssh_client_from_settings_with_password("bandit", 6, level6_password().await).await;
-    //     let result = client.execute("echo hello").await.unwrap();
-    //     assert_eq!("hello\n", result.stdout);
-    //     assert_eq!(0, result.exit_status);
-    // }
-
-    // #[tokio::test]
-    // async fn level5_password_returns_proper_value() {
-    //     let client =
-    //         get_ssh_client_from_settings_with_password("bandit", 5, level5_password().await).await;
-    //     let result = client.execute("echo hello").await.unwrap();
-    //     assert_eq!("hello\n", result.stdout);
-    //     assert_eq!(0, result.exit_status);
-    // }
-
-    // #[tokio::test]
-    // async fn level4_password_returns_proper_value() {
-    //     let client =
-    //         get_ssh_client_from_settings_with_password("bandit", 4, level4_password().await).await;
-    //     let result = client.execute("echo hello").await.unwrap();
-    //     assert_eq!("hello\n", result.stdout);
-    //     assert_eq!(0, result.exit_status);
-    // }
-
-    // #[tokio::test]
-    // async fn level3_password_returns_proper_value() {
-    //     let client =
-    //         get_ssh_client_from_settings_with_password("bandit", 3, level3_password().await).await;
-    //     let result = client.execute("echo hello").await.unwrap();
-    //     assert_eq!("hello\n", result.stdout);
-    //     assert_eq!(0, result.exit_status);
-    // }
-
-    // #[tokio::test]
-    // async fn level2_password_returns_proper_value() {
-    //     let client =
-    //         get_ssh_client_from_settings_with_password("bandit", 2, level2_password().await).await;
-    //     let result = client.execute("echo hello").await.unwrap();
-    //     assert_eq!("hello\n", result.stdout);
-    //     assert_eq!(0, result.exit_status);
-    // }
+    // test_bandit_level!(9);
+    // test_bandit_level!(8);
+    // test_bandit_level!(7);
+    // test_bandit_level!(6);
+    // test_bandit_level!(5);
+    // test_bandit_level!(4);
+    // test_bandit_level!(3);
+    // test_bandit_level!(2);
+    // test_bandit_level!(1);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,23 @@
 
 use async_ssh2_tokio::client::{AuthMethod, Client, ServerCheckMethod};
 use config::Config;
+use paste::paste;
+
+#[macro_use]
+macro_rules! test_ssh_wargame_level {
+    ($wargame:literal, $level:literal) => {
+        paste! {
+            #[tokio::test]
+            async fn [<level $level _password_returns_proper_value>]() {
+                let client =
+                    get_ssh_client_from_settings_with_password($wargame, $level, [<level $level _password>]().await).await;
+                let result = client.execute("echo hello").await.unwrap();
+                assert_eq!("hello\n", result.stdout);
+                assert_eq!(0, result.exit_status);
+            }
+        }
+    };
+}
 
 pub mod bandit;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,11 @@
 
 use async_ssh2_tokio::client::{AuthMethod, Client, ServerCheckMethod};
 use config::Config;
-use paste::paste;
 
-#[macro_use]
-macro_rules! test_ssh_wargame_level {
+#[allow(unused_macros)]
+macro_rules! test_ssh_level {
     ($wargame:literal, $level:literal) => {
-        paste! {
+        paste::paste! {
             #[tokio::test]
             async fn [<level $level _password_returns_proper_value>]() {
                 let client =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,22 +15,6 @@
 use async_ssh2_tokio::client::{AuthMethod, Client, ServerCheckMethod};
 use config::Config;
 
-#[allow(unused_macros)]
-macro_rules! test_ssh_level {
-    ($wargame:literal, $level:literal) => {
-        paste::paste! {
-            #[tokio::test]
-            async fn [<level $level _password_returns_proper_value>]() {
-                let client =
-                    get_ssh_client_from_settings_with_password($wargame, $level, [<level $level _password>]().await).await;
-                let result = client.execute("echo hello").await.unwrap();
-                assert_eq!("hello\n", result.stdout);
-                assert_eq!(0, result.exit_status);
-            }
-        }
-    };
-}
-
 pub mod bandit;
 
 /// Load the settings for a given wargame
@@ -152,6 +136,25 @@ pub async fn get_ssh_client_from_settings_with_password(
     .await
     .unwrap()
 }
+
+#[allow(unused_macros)]
+macro_rules! test_ssh_level {
+    ($wargame:literal, $level:literal) => {
+        paste::paste! {
+            #[tokio::test]
+            async fn [<level $level _password_returns_proper_value>]() {
+                let client =
+                    get_ssh_client_from_settings_with_password($wargame, $level, [<level $level _password>]().await).await;
+                let result = client.execute("echo hello").await.unwrap();
+                assert_eq!("hello\n", result.stdout);
+                assert_eq!(0, result.exit_status);
+            }
+        }
+    };
+}
+
+#[allow(unused_imports)]
+pub(crate) use test_ssh_level;
 
 #[cfg(not(tarpaulin_include))]
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,22 @@ macro_rules! test_ssh_level {
 #[allow(unused_imports)]
 pub(crate) use test_ssh_level;
 
+#[allow(unused_macros)]
+macro_rules! ssh_single_command_level {
+    ($wargame:literal, $level:literal, $command:literal) => {
+        paste! {
+            pub async fn [<level $level _password>]() -> String {
+                let client = get_ssh_client_from_settings($wargame, $level - 1).await;
+                let result = client.execute($command).await.unwrap();
+                result.stdout.trim().to_string()
+            }
+        }
+    };
+}
+
+#[allow(unused_imports)]
+pub(crate) use ssh_single_command_level;
+
 #[cfg(not(tarpaulin_include))]
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,14 +137,16 @@ pub async fn get_ssh_client_from_settings_with_password(
     .unwrap()
 }
 
-#[allow(unused_macros)]
-macro_rules! test_ssh_level {
+#[cfg(not(tarpaulin_include))]
+mod macros {
+    #[allow(unused_macros)]
+    macro_rules! test_ssh_level {
     ($wargame:literal, $level:literal) => {
         paste::paste! {
             #[tokio::test]
             async fn [<level $level _password_returns_proper_value>]() {
                 let client =
-                    get_ssh_client_from_settings_with_password($wargame, $level, [<level $level _password>]().await).await;
+                    crate::get_ssh_client_from_settings_with_password($wargame, $level, [<level $level _password>]().await).await;
                 let result = client.execute("echo hello").await.unwrap();
                 assert_eq!("hello\n", result.stdout);
                 assert_eq!(0, result.exit_status);
@@ -153,24 +155,25 @@ macro_rules! test_ssh_level {
     };
 }
 
-#[allow(unused_imports)]
-pub(crate) use test_ssh_level;
+    #[allow(unused_imports)]
+    pub(crate) use test_ssh_level;
 
-#[allow(unused_macros)]
-macro_rules! ssh_single_command_level {
-    ($wargame:literal, $level:literal, $command:literal) => {
-        paste! {
-            pub async fn [<level $level _password>]() -> String {
-                let client = get_ssh_client_from_settings($wargame, $level - 1).await;
-                let result = client.execute($command).await.unwrap();
-                result.stdout.trim().to_string()
+    #[allow(unused_macros)]
+    macro_rules! ssh_single_command_level {
+        ($wargame:literal, $level:literal, $command:literal) => {
+            paste! {
+                pub async fn [<level $level _password>]() -> String {
+                    let client = crate::get_ssh_client_from_settings($wargame, $level - 1).await;
+                    let result = client.execute($command).await.unwrap();
+                    result.stdout.trim().to_string()
+                }
             }
-        }
-    };
-}
+        };
+    }
 
-#[allow(unused_imports)]
-pub(crate) use ssh_single_command_level;
+    #[allow(unused_imports)]
+    pub(crate) use ssh_single_command_level;
+}
 
 #[cfg(not(tarpaulin_include))]
 #[cfg(test)]


### PR DESCRIPTION
- Add paste crate
- Test a macro to generate the common fnc
- Build test macro
- Tidy test_ssh_level
- Change how macros are imported
- Refactor bandit ssh tests
- Create macro for SSH levels with a single command
- Set up bandit level using macro
- Refactor bandit levels
- Hide macros in module for coverage
